### PR TITLE
Fix code scanning alert no. 28: Unsafe HTML constructed from library input

### DIFF
--- a/package.json
+++ b/package.json
@@ -410,7 +410,8 @@
     "uuid": "9.0.1",
     "visjs-network": "4.25.0",
     "whatwg-fetch": "3.6.20",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
+    "dompurify": "^3.1.7"
   },
   "resolutions": {
     "underscore": "1.13.7",

--- a/public/vendor/flot/jquery.flot.js
+++ b/public/vendor/flot/jquery.flot.js
@@ -5,6 +5,8 @@ Licensed under the MIT license.
 
 */
 
+const DOMPurify = require('dompurify');
+
 // first an inline dependency, jquery.colorhelpers.js, we inline it here
 // for convenience
 
@@ -2916,6 +2918,7 @@ Licensed under the MIT license.
             c.a = 1;
             c = c.toString();
           }
+          c = DOMPurify.sanitize(c); // Sanitize the backgroundColor value
           var div = legend.children();
           $('<div style="position:absolute;width:' + div.width() + 'px;height:' + div.height() + 'px;' + pos + 'background-color:' + c + ';"> </div>').prependTo(legend).css('opacity', options.legend.backgroundOpacity);
         }


### PR DESCRIPTION
Fixes [https://github.com/Apetree100122/grafana/security/code-scanning/28](https://github.com/Apetree100122/grafana/security/code-scanning/28)

To fix the problem, we need to ensure that any dynamic HTML construction using potentially untrusted input is sanitized. The best way to fix this issue without changing existing functionality is to sanitize the `backgroundColor` value before using it to construct HTML. We can use a library like `DOMPurify` to sanitize the input.

1. Import the `DOMPurify` library.
2. Sanitize the `backgroundColor` value before using it in the HTML construction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
